### PR TITLE
POC – Fixed #1688 -- Output translatable labels when displaying permissions

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -76,18 +76,18 @@ class Permission(models.Model):
         ordering = ["content_type__app_label", "content_type__model", "codename"]
 
     def __str__(self):
-        names = { "verbose_name_plural": self.content_type.name_plural, "app_verbose_name": self.content_type.app_verbose_name }
+        names = { "content_type": self.content_type }
 
         if "Can add" in self.name:
-            return _("Can add %(verbose_name_plural)s | %(app_verbose_name)s") % names
+            return _("%(content_type)s | Can add") % names
         if "Can change" in self.name:
-            return _("Can change %(verbose_name_plural)s | %(app_verbose_name)s") % names
+            return _("%(content_type)s | Can change") % names
         if "Can delete" in self.name:
-            return _("Can delete %(verbose_name_plural)s | %(app_verbose_name)s") % names
+            return _("%(content_type)s | Can delete") % names
         if "Can view" in self.name:
-            return _("Can view %(verbose_name_plural)s | %(app_verbose_name)s") % names
+            return _("%(content_type)s | Can view") % names
 
-        return "%s | %s | %s" % (self.name, self.content_type.name_plural, self.content_type.app_verbose_name)
+        return "%s | %s | %s" % (self.content_type, self.name)
 
     def natural_key(self):
         return (self.codename,) + self.content_type.natural_key()

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -76,7 +76,18 @@ class Permission(models.Model):
         ordering = ["content_type__app_label", "content_type__model", "codename"]
 
     def __str__(self):
-        return "%s | %s" % (self.content_type, self.name)
+        names = { "verbose_name_plural": self.content_type.name_plural, "app_verbose_name": self.content_type.app_verbose_name }
+
+        if "Can add" in self.name:
+            return _("Can add %(verbose_name_plural)s | %(app_verbose_name)s") % names
+        if "Can change" in self.name:
+            return _("Can change %(verbose_name_plural)s | %(app_verbose_name)s") % names
+        if "Can delete" in self.name:
+            return _("Can delete %(verbose_name_plural)s | %(app_verbose_name)s") % names
+        if "Can view" in self.name:
+            return _("Can view %(verbose_name_plural)s | %(app_verbose_name)s") % names
+
+        return "%s | %s | %s" % (self.name, self.content_type.name_plural, self.content_type.app_verbose_name)
 
     def natural_key(self):
         return (self.codename,) + self.content_type.natural_key()

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -158,13 +158,6 @@ class ContentType(models.Model):
         return str(model._meta.verbose_name)
 
     @property
-    def name_plural(self):
-        model = self.model_class()
-        if not model:
-            return self.model
-        return str(model._meta.verbose_name_plural)
-
-    @property
     def app_labeled_name(self):
         model = self.model_class()
         if not model:
@@ -173,13 +166,6 @@ class ContentType(models.Model):
             model._meta.app_config.verbose_name,
             model._meta.verbose_name,
         )
-
-    @property
-    def app_verbose_name(self):
-        model = self.model_class()
-        if not model:
-            return ""
-        return apps.get_app_config(model._meta.app_label).verbose_name
 
     def model_class(self):
         """Return the model class for this type of content."""

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -158,6 +158,13 @@ class ContentType(models.Model):
         return str(model._meta.verbose_name)
 
     @property
+    def name_plural(self):
+        model = self.model_class()
+        if not model:
+            return self.model
+        return str(model._meta.verbose_name_plural)
+
+    @property
     def app_labeled_name(self):
         model = self.model_class()
         if not model:
@@ -166,6 +173,13 @@ class ContentType(models.Model):
             model._meta.app_config.verbose_name,
             model._meta.verbose_name,
         )
+
+    @property
+    def app_verbose_name(self):
+        model = self.model_class()
+        if not model:
+            return ""
+        return apps.get_app_config(model._meta.app_label).verbose_name
 
     def model_class(self):
         """Return the model class for this type of content."""


### PR DESCRIPTION
Demos of a potential fix for https://code.djangoproject.com/ticket/1688.

See discussions: 

- https://forum.djangoproject.com/t/permissions-dont-get-translated-in-admin-interface/21324
- https://groups.google.com/g/django-developers/c/Jv1GqGlp3ao/m/n0jc36kZBAAJ

---

Second PoC (latest), based on [django#16053](https://github.com/django/django/pull/16053) – resulting labels:

![](https://github.com/thibaudcolas/django/assets/877585/74a1f305-8e23-436b-971e-cac84b498259)

---

First PoC: see commit [89eb783e46d98d5092840df560c6eb8dc06e27c5](https://github.com/thibaudcolas/django/pull/1/commits/89eb783e46d98d5092840df560c6eb8dc06e27c5). Resulting labels:

![1688](https://user-images.githubusercontent.com/877585/195763100-14406db0-6bce-407d-b168-2e38b0ec2658.png)